### PR TITLE
make rectangle view 100% width to be shown for flex parents

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,9 +130,9 @@ const Rectangle = (props) => {
 
         for (let i = 0; i < props.rows; i++) {
             rectangles.push(
-                <View key={i} style={{ backgroundColor: props.color, marginLeft: 5, marginBottom: 10 }}>
+                <View key={i} style={{ backgroundColor: props.color, marginLeft: 5, marginBottom: 10, width: '100%' }}>
                     <Animated.View style={{ opacity: props.fadeAnim }} >
-                        <View style = {{ backgroundColor: props.highlightColor, height: props.height }}>
+                        <View style = {{ backgroundColor: props.highlightColor, height: props.height, width: '100%' }}>
                         </View>
                     </Animated.View>
                 </View>


### PR DESCRIPTION
This change will fix an unexpected behavior about how `Rectangle` view in shown when its parent is using flex in its style, please checkout this Snack I did for shown the error.

[Snack Test](https://snack.expo.io/@johuder33/react-native-skeleton)

thank you, amazing and useful lib.