### PR TITLE
fix a bug that makes the Square component inaccessible

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ export default class Skeleton extends Component {
   }
 }
 
- Square = (props) => {
+const Square = (props) => {
      if (props.loading) {
          return (
             <View style={{ backgroundColor: props.color, height: props.size, width: props.size }}>


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug that shows up when the user wants to display a skeleton loader with the type prop having a value of square

#### Description of task completed
The Square variable was not declared and as such was not accessible